### PR TITLE
Feature / Limit the number of scores in feed

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,9 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.includes(:user)
+                        .order(played_at: :desc, id: :desc)
+                        .limit(25)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -26,6 +26,30 @@ describe Api::ScoresController, type: :request do
       expect(scores[1]['total_score']).to eq 68
       expect(scores[2]['total_score']).to eq 79
     end
+
+    it 'should return at most 25 most recent scores' do
+      rng = Random.new
+
+      30.times do |i|
+        user = User.create!(name: "User#{i}", email: "user#{i}@example.com")
+        Score.create!(
+          user: user,
+          total_score: rng.rand(66..99),
+          played_at: Date.today - i.days
+        )
+      end
+
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+      response_hash = JSON.parse(response.body)
+      scores = response_hash['scores']
+
+      expect(scores.size).to eq 25
+
+      played_at_dates = scores.map { |s| Date.parse(s['played_at']) }
+      expect(played_at_dates).to eq played_at_dates.sort.reverse
+    end
   end
 
   describe 'POST create' do


### PR DESCRIPTION
Fixes: https://github.com/AACraiu/golfr_backend/issues/21

**Changes**

I restricted the query to only return the most recent 25 scores. 
I added a test that tests this case.

**Before**
Before implementation, all scores were retrieved from the database and displayed.

<img width="2204" height="1010" alt="Screenshot 2025-10-08 at 13 43 23" src="https://github.com/user-attachments/assets/902efe8d-723e-4ad8-a4c2-9f7ad5df6528" />

**After**
After the implementation, only the most recent 25 scores are retrieved from the database and displayed. 

<img width="2177" height="876" alt="Screenshot 2025-10-08 at 13 42 47" src="https://github.com/user-attachments/assets/31618fd4-fd40-4294-bef2-3823cb42ecc9" />
